### PR TITLE
ci: fix GitHub Actions failures

### DIFF
--- a/.github/workflows/docker-integration.yml
+++ b/.github/workflows/docker-integration.yml
@@ -23,6 +23,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  P2P_DDNS_NO_MDNS: "1"
 
 jobs:
   smoke:

--- a/src/cli/paths.rs
+++ b/src/cli/paths.rs
@@ -93,15 +93,19 @@ mod tests {
 
     #[test]
     fn storage_db_path_accepts_db_file_config() {
-        let mut args = DaemonArgs::default();
-        args.config = Some(PathBuf::from("/tmp/p2p-ddns.db"));
+        let args = DaemonArgs {
+            config: Some(PathBuf::from("/tmp/p2p-ddns.db")),
+            ..DaemonArgs::default()
+        };
         assert_eq!(storage_db_path(&args), PathBuf::from("/tmp/p2p-ddns.db"));
     }
 
     #[test]
     fn storage_db_path_uses_dir_config() {
-        let mut args = DaemonArgs::default();
-        args.config = Some(PathBuf::from("/tmp/p2p-ddns"));
+        let args = DaemonArgs {
+            config: Some(PathBuf::from("/tmp/p2p-ddns")),
+            ..DaemonArgs::default()
+        };
         assert_eq!(
             storage_db_path(&args),
             PathBuf::from("/tmp/p2p-ddns").join("storage.db")

--- a/tests/admin_handler.rs
+++ b/tests/admin_handler.rs
@@ -14,16 +14,18 @@ use tempfile::tempdir;
 
 async fn make_context() -> Result<(p2p_ddns::net::Context, Arc<ClientRegistry>)> {
     let dir = tempdir()?;
-    let mut args = DaemonArgs::default();
-    args.daemon = true;
-    args.primary = true;
-    args.domain = Some("a".to_string());
-    args.config = Some(dir.path().to_path_buf());
-    args.bind = Some("127.0.0.1:0".to_string());
-    args.no_mdns = true;
-    args.dht = false;
-    args.hosts_sync = true;
-    args.hosts_path = Some(dir.path().join("hosts"));
+    let args = DaemonArgs {
+        daemon: true,
+        primary: true,
+        domain: Some("a".to_string()),
+        config: Some(dir.path().to_path_buf()),
+        bind: Some("127.0.0.1:0".to_string()),
+        no_mdns: true,
+        dht: false,
+        hosts_sync: true,
+        hosts_path: Some(dir.path().join("hosts")),
+        ..DaemonArgs::default()
+    };
     DaemonArgs::validate(&args)?;
 
     let storage = Storage::new(dir.path().join("storage.db"))?;

--- a/tests/admin_http.rs
+++ b/tests/admin_http.rs
@@ -14,14 +14,16 @@ use tokio::{io::AsyncReadExt, io::AsyncWriteExt, net::TcpStream};
 
 async fn make_ctx_and_clients() -> Result<(Arc<p2p_ddns::net::Context>, Arc<ClientRegistry>)> {
     let dir = tempdir()?;
-    let mut args = DaemonArgs::default();
-    args.daemon = true;
-    args.primary = true;
-    args.domain = Some("a".to_string());
-    args.config = Some(dir.path().to_path_buf());
-    args.bind = Some("127.0.0.1:0".to_string());
-    args.no_mdns = true;
-    args.dht = false;
+    let args = DaemonArgs {
+        daemon: true,
+        primary: true,
+        domain: Some("a".to_string()),
+        config: Some(dir.path().to_path_buf()),
+        bind: Some("127.0.0.1:0".to_string()),
+        no_mdns: true,
+        dht: false,
+        ..DaemonArgs::default()
+    };
     DaemonArgs::validate(&args)?;
 
     let storage = Storage::new(dir.path().join("storage.db"))?;

--- a/tests/admin_unix_socket.rs
+++ b/tests/admin_unix_socket.rs
@@ -16,14 +16,16 @@ use tokio::{io::AsyncReadExt, io::AsyncWriteExt, net::UnixStream};
 
 async fn make_ctx_and_clients() -> Result<(Arc<p2p_ddns::net::Context>, Arc<ClientRegistry>)> {
     let dir = tempdir()?;
-    let mut args = DaemonArgs::default();
-    args.daemon = true;
-    args.primary = true;
-    args.domain = Some("a".to_string());
-    args.config = Some(dir.path().to_path_buf());
-    args.bind = Some("127.0.0.1:0".to_string());
-    args.no_mdns = true;
-    args.dht = false;
+    let args = DaemonArgs {
+        daemon: true,
+        primary: true,
+        domain: Some("a".to_string()),
+        config: Some(dir.path().to_path_buf()),
+        bind: Some("127.0.0.1:0".to_string()),
+        no_mdns: true,
+        dht: false,
+        ..DaemonArgs::default()
+    };
     DaemonArgs::validate(&args)?;
 
     let storage = Storage::new(dir.path().join("storage.db"))?;

--- a/tests/docker_p2p.rs
+++ b/tests/docker_p2p.rs
@@ -90,6 +90,10 @@ fn env_bool(key: &str) -> bool {
     )
 }
 
+fn env_nonempty(key: &str) -> Option<String> {
+    env::var(key).ok().filter(|v| !v.trim().is_empty())
+}
+
 fn env_usize(key: &str) -> Result<Option<usize>> {
     let Ok(value) = env::var(key) else {
         return Ok(None);
@@ -397,10 +401,10 @@ fn extract_ticket(text: &str) -> Option<String> {
         if let Some(t) = extract_after_prefix(line, "New Ticket: ") {
             return Some(t);
         }
-        if let Some(t) = extract_after_prefix(line, "Ticket: ") {
-            if t.len() > 16 {
-                return Some(t);
-            }
+        if let Some(t) = extract_after_prefix(line, "Ticket: ")
+            && t.len() > 16
+        {
+            return Some(t);
         }
     }
     None
@@ -475,14 +479,11 @@ async fn wait_for_primary_converged(
     let deadline = Instant::now() + timeout;
     let mut last_out = String::new();
     loop {
-        match primary_list(primary, ticket).await {
-            Ok(out) => {
-                last_out = out.clone();
-                if expected_names.iter().all(|n| out.contains(n)) {
-                    return Ok(());
-                }
+        if let Ok(out) = primary_list(primary, ticket).await {
+            last_out = out.clone();
+            if expected_names.iter().all(|n| out.contains(n)) {
+                return Ok(());
             }
-            Err(_) => {}
         }
 
         if Instant::now() >= deadline {
@@ -627,18 +628,15 @@ async fn assert_primary_missing_for(
     let deadline = Instant::now() + duration;
     let mut last_out = String::new();
     loop {
-        match primary_list(primary, ticket).await {
-            Ok(out) => {
-                last_out = out.clone();
-                if forbidden_names.iter().any(|n| out.contains(n)) {
-                    anyhow::bail!(
-                        "primary unexpectedly listed a forbidden node; forbidden={:?}\n{}",
-                        forbidden_names,
-                        out
-                    );
-                }
+        if let Ok(out) = primary_list(primary, ticket).await {
+            last_out = out.clone();
+            if forbidden_names.iter().any(|n| out.contains(n)) {
+                anyhow::bail!(
+                    "primary unexpectedly listed a forbidden node; forbidden={:?}\n{}",
+                    forbidden_names,
+                    out
+                );
             }
-            Err(_) => {}
         }
 
         if Instant::now() >= deadline {
@@ -679,7 +677,7 @@ async fn run_case(case: Case, tag: &str) -> Result<()> {
         1
     };
     let primary = {
-        GenericImage::new("p2p-ddns-test-primary", tag)
+        let mut image = GenericImage::new("p2p-ddns-test-primary", tag)
             .with_container_name(primary_container_name.clone())
             .with_env_var("NODE_NAME", "primary-node")
             .with_env_var("P2P_DDNS_LOG_LEVEL", "debug")
@@ -687,10 +685,11 @@ async fn run_case(case: Case, tag: &str) -> Result<()> {
             .with_env_var("P2P_DDNS_BIND_ADDRESS", "0.0.0.0:7777")
             .with_env_var("P2P_DDNS_EXPECT_IPV4", primary_expected_ipv4.to_string())
             .with_env_var("XDG_RUNTIME_DIR", "/tmp")
-            .with_network(networks.first().context("missing primary network")?.clone())
-            .start()
-            .await
-            .context("start primary container")?
+            .with_network(networks.first().context("missing primary network")?.clone());
+        if let Some(v) = env_nonempty("P2P_DDNS_NO_MDNS") {
+            image = image.with_env_var("P2P_DDNS_NO_MDNS", v);
+        }
+        image.start().await.context("start primary container")?
     };
 
     // testcontainers-rs only attaches to one network at creation time; multi-home here.
@@ -733,7 +732,7 @@ async fn run_case(case: Case, tag: &str) -> Result<()> {
                 1
             };
 
-            let container = GenericImage::new("p2p-ddns-test-daemon", tag)
+            let mut image = GenericImage::new("p2p-ddns-test-daemon", tag)
                 .with_container_name(container_name)
                 .with_env_var("NODE_NAME", name.clone())
                 .with_env_var("P2P_DDNS_LOG_LEVEL", "info")
@@ -743,7 +742,11 @@ async fn run_case(case: Case, tag: &str) -> Result<()> {
                 .with_env_var("PRIMARY_HOST", primary_host_for_ping)
                 .with_env_var("P2P_DDNS_EXPECT_IPV4", expected_ipv4.to_string())
                 .with_env_var("XDG_RUNTIME_DIR", "/tmp")
-                .with_network(initial_network.clone())
+                .with_network(initial_network.clone());
+            if let Some(v) = env_nonempty("P2P_DDNS_NO_MDNS") {
+                image = image.with_env_var("P2P_DDNS_NO_MDNS", v);
+            }
+            let container = image
                 .start()
                 .await
                 .with_context(|| format!("start daemon container: {name}"))?;
@@ -858,52 +861,50 @@ async fn run_case(case: Case, tag: &str) -> Result<()> {
     }
     .await;
 
-    if res.is_err() {
-        if let Some(ticket) = ticket_for_debug.as_deref() {
-            if let Ok(out) = primary_list(&primary, ticket).await {
-                let expected = daemon_names(case.daemon_count);
-                let missing = expected
-                    .iter()
-                    .filter(|n| !out.contains(n.as_str()))
-                    .cloned()
-                    .collect::<Vec<_>>();
-                eprintln!("Primary list (debug):\n{out}");
+    if res.is_err()
+        && let Some(ticket) = ticket_for_debug.as_deref()
+        && let Ok(out) = primary_list(&primary, ticket).await
+    {
+        let expected = daemon_names(case.daemon_count);
+        let missing = expected
+            .iter()
+            .filter(|n| !out.contains(n.as_str()))
+            .cloned()
+            .collect::<Vec<_>>();
+        eprintln!("Primary list (debug):\n{out}");
 
-                for name in missing {
-                    let idx = name
-                        .strip_prefix("daemon-")
-                        .and_then(|s| s.parse::<usize>().ok())
-                        .and_then(|n| n.checked_sub(1));
-                    let Some(idx) = idx else {
-                        continue;
-                    };
-                    let Some(daemon) = daemons.get(idx) else {
-                        continue;
-                    };
-                    let tail = docker_logs_tail(daemon.id(), 200).unwrap_or_else(|e| {
-                        format!("(failed to read docker logs for {name}: {e:#})")
-                    });
-                    let mut excerpt = String::new();
-                    for line in tail.lines() {
-                        if line.contains("p2p_ddns") || line.contains("Timeout joining gossip") {
-                            excerpt.push_str(line);
-                            excerpt.push('\n');
-                        }
-                    }
-                    if excerpt.trim().is_empty() {
-                        excerpt = tail
-                            .lines()
-                            .rev()
-                            .take(40)
-                            .collect::<Vec<_>>()
-                            .into_iter()
-                            .rev()
-                            .collect::<Vec<_>>()
-                            .join("\n");
-                    }
-                    eprintln!("----- {name} logs (filtered) -----\n{excerpt}");
+        for name in missing {
+            let idx = name
+                .strip_prefix("daemon-")
+                .and_then(|s| s.parse::<usize>().ok())
+                .and_then(|n| n.checked_sub(1));
+            let Some(idx) = idx else {
+                continue;
+            };
+            let Some(daemon) = daemons.get(idx) else {
+                continue;
+            };
+            let tail = docker_logs_tail(daemon.id(), 200)
+                .unwrap_or_else(|e| format!("(failed to read docker logs for {name}: {e:#})"));
+            let mut excerpt = String::new();
+            for line in tail.lines() {
+                if line.contains("p2p_ddns") || line.contains("Timeout joining gossip") {
+                    excerpt.push_str(line);
+                    excerpt.push('\n');
                 }
             }
+            if excerpt.trim().is_empty() {
+                excerpt = tail
+                    .lines()
+                    .rev()
+                    .take(40)
+                    .collect::<Vec<_>>()
+                    .into_iter()
+                    .rev()
+                    .collect::<Vec<_>>()
+                    .join("\n");
+            }
+            eprintln!("----- {name} logs (filtered) -----\n{excerpt}");
         }
     }
 

--- a/tests/hosts_sync.rs
+++ b/tests/hosts_sync.rs
@@ -10,17 +10,19 @@ async fn hosts_sync_writes_and_cleans_managed_section_on_shutdown() -> Result<()
     let hosts_path = dir.path().join("hosts");
     std::fs::write(&hosts_path, "127.0.0.1 localhost\n")?;
 
-    let mut args = DaemonArgs::default();
-    args.daemon = false;
-    args.primary = true;
-    args.domain = Some("alpha".to_string());
-    args.config = Some(dir.path().to_path_buf());
-    args.bind = Some("127.0.0.1:0".to_string());
-    args.no_mdns = true;
-    args.dht = false;
-    args.hosts_sync = true;
-    args.hosts_path = Some(hosts_path.clone());
-    args.hosts_suffix = Some("p2p".to_string());
+    let args = DaemonArgs {
+        daemon: false,
+        primary: true,
+        domain: Some("alpha".to_string()),
+        config: Some(dir.path().to_path_buf()),
+        bind: Some("127.0.0.1:0".to_string()),
+        no_mdns: true,
+        dht: false,
+        hosts_sync: true,
+        hosts_path: Some(hosts_path.clone()),
+        hosts_suffix: Some("p2p".to_string()),
+        ..DaemonArgs::default()
+    };
     DaemonArgs::validate(&args)?;
 
     let storage = Storage::new(dir.path().join("storage.db"))?;

--- a/tests/integration/nodes/daemon/entrypoint.sh
+++ b/tests/integration/nodes/daemon/entrypoint.sh
@@ -145,6 +145,11 @@ setup_config() {
         ARGS+=("--bind" "$P2P_DDNS_BIND_ADDRESS")
     fi
 
+    if bool "${P2P_DDNS_NO_MDNS:-0}"; then
+        log "Disabling mDNS discovery"
+        ARGS+=("--no-mdns")
+    fi
+
     if bool "${P2P_DDNS_HOSTS_SYNC:-1}"; then
         log "Enabling hosts synchronization"
         ARGS+=("--hosts-sync")

--- a/tests/integration/nodes/primary/entrypoint.sh
+++ b/tests/integration/nodes/primary/entrypoint.sh
@@ -100,6 +100,11 @@ setup_config() {
         ARGS+=("--bind" "$P2P_DDNS_BIND_ADDRESS")
     fi
 
+    if bool "${P2P_DDNS_NO_MDNS:-0}"; then
+        log "Disabling mDNS discovery"
+        ARGS+=("--no-mdns")
+    fi
+
     if bool "${P2P_DDNS_HOSTS_SYNC:-1}"; then
         log "Enabling hosts synchronization"
         ARGS+=("--hosts-sync")

--- a/tests/local_join_sync.rs
+++ b/tests/local_join_sync.rs
@@ -9,29 +9,33 @@ async fn local_join_sync_over_ipv4_loopback() -> Result<()> {
     let dir_a = tempfile::tempdir()?;
     let dir_b = tempfile::tempdir()?;
 
-    let mut args_a = DaemonArgs::default();
-    args_a.daemon = false;
-    args_a.primary = true;
-    args_a.domain = Some("a".to_string());
-    args_a.config = Some(dir_a.path().to_path_buf());
-    args_a.bind = Some("127.0.0.1:0".to_string());
-    args_a.no_mdns = true;
-    args_a.dht = false;
+    let args_a = DaemonArgs {
+        daemon: false,
+        primary: true,
+        domain: Some("a".to_string()),
+        config: Some(dir_a.path().to_path_buf()),
+        bind: Some("127.0.0.1:0".to_string()),
+        no_mdns: true,
+        dht: false,
+        ..DaemonArgs::default()
+    };
     DaemonArgs::validate(&args_a)?;
 
     let storage_a = Storage::new(dir_a.path().join("storage.db"))?;
     let (ctx_a, gos_a, sp_a) = init_network(args_a, storage_a).await?;
     let ticket = ctx_a.ticket.to_string();
 
-    let mut args_b = DaemonArgs::default();
-    args_b.daemon = false;
-    args_b.primary = false;
-    args_b.domain = Some("b".to_string());
-    args_b.ticket = Some(ticket);
-    args_b.config = Some(dir_b.path().to_path_buf());
-    args_b.bind = Some("127.0.0.1:0".to_string());
-    args_b.no_mdns = true;
-    args_b.dht = false;
+    let args_b = DaemonArgs {
+        daemon: false,
+        primary: false,
+        domain: Some("b".to_string()),
+        ticket: Some(ticket),
+        config: Some(dir_b.path().to_path_buf()),
+        bind: Some("127.0.0.1:0".to_string()),
+        no_mdns: true,
+        dht: false,
+        ..DaemonArgs::default()
+    };
     DaemonArgs::validate(&args_b)?;
 
     let storage_b = Storage::new(dir_b.path().join("storage.db"))?;

--- a/tests/local_join_sync_ipv6.rs
+++ b/tests/local_join_sync_ipv6.rs
@@ -9,29 +9,33 @@ async fn local_join_sync_over_ipv6_loopback() -> Result<()> {
     let dir_a = tempfile::tempdir()?;
     let dir_b = tempfile::tempdir()?;
 
-    let mut args_a = DaemonArgs::default();
-    args_a.daemon = false;
-    args_a.primary = true;
-    args_a.domain = Some("a6".to_string());
-    args_a.config = Some(dir_a.path().to_path_buf());
-    args_a.bind = Some("[::1]:0".to_string());
-    args_a.no_mdns = true;
-    args_a.dht = false;
+    let args_a = DaemonArgs {
+        daemon: false,
+        primary: true,
+        domain: Some("a6".to_string()),
+        config: Some(dir_a.path().to_path_buf()),
+        bind: Some("[::1]:0".to_string()),
+        no_mdns: true,
+        dht: false,
+        ..DaemonArgs::default()
+    };
     DaemonArgs::validate(&args_a)?;
 
     let storage_a = Storage::new(dir_a.path().join("storage.db"))?;
     let (ctx_a, gos_a, sp_a) = init_network(args_a, storage_a).await?;
     let ticket = ctx_a.ticket.to_string();
 
-    let mut args_b = DaemonArgs::default();
-    args_b.daemon = false;
-    args_b.primary = false;
-    args_b.domain = Some("b6".to_string());
-    args_b.ticket = Some(ticket);
-    args_b.config = Some(dir_b.path().to_path_buf());
-    args_b.bind = Some("[::1]:0".to_string());
-    args_b.no_mdns = true;
-    args_b.dht = false;
+    let args_b = DaemonArgs {
+        daemon: false,
+        primary: false,
+        domain: Some("b6".to_string()),
+        ticket: Some(ticket),
+        config: Some(dir_b.path().to_path_buf()),
+        bind: Some("[::1]:0".to_string()),
+        no_mdns: true,
+        dht: false,
+        ..DaemonArgs::default()
+    };
     DaemonArgs::validate(&args_b)?;
 
     let storage_b = Storage::new(dir_b.path().join("storage.db"))?;


### PR DESCRIPTION
## Summary
- fix clippy warnings that fail the Rust checks job
- make docker test entrypoints honor a CI-only no-mdns toggle
- disable mDNS in GitHub Actions docker runs where the runner network cannot bind discovery sockets

## Validation
- cargo clippy --all-targets -- -D warnings
- cargo test -- --skip docker_p2p_smoke --skip docker_p2p_matrix --skip docker_p2p_expected_failures
- P2P_DDNS_NO_MDNS=1 cargo test --test docker_p2p docker_p2p_smoke -- --nocapture